### PR TITLE
Test/valid request canceled events

### DIFF
--- a/src/test/java/com/theheroloop/events/MessageTest.java
+++ b/src/test/java/com/theheroloop/events/MessageTest.java
@@ -1,10 +1,10 @@
 package com.theheroloop.events;
 
 import static com.theheroloop.events.EventType.HEROES_AVAILABLE_NEAR_LOOPER;
+import static com.theheroloop.events.EventType.REQUEST_CANCELED;
 import static com.theheroloop.events.MessageField.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import com.theheroloop.events.json.JsonDeserializer;
 
@@ -30,6 +30,33 @@ public class MessageTest
     assertEquals( "1023", map.get( LOOPER_ID_FIELD.fieldName() ) );
     assertEquals( "H1", map.get( HERO_ID_FIELD.fieldName() ) );
     assertEquals( "23", map.get( REQUEST_ID_FIELD.fieldName() ) );
+  }
+
+  @Test
+  public void testIsValidRequestCanceledMessageWithJustRequiredFields()
+  {
+    var message = MessageBuilder.for_( REQUEST_CANCELED )
+    . setLooperId( "1023" )
+    . setRequestId( "23" )
+    . build();
+
+    var valid = message.isValid();
+
+    assertTrue( valid );
+  }
+
+  @Test
+  public void testIsValidRequestCanceledMessageWithAdditionalHeroIdField()
+  {
+    var message = MessageBuilder.for_( REQUEST_CANCELED )
+    . setHeroId( "33" )
+    . setLooperId( "1023" )
+    . setRequestId( "23" )
+    . build();
+
+    var valid = message.isValid();
+
+    assertTrue( valid );
   }
 
 }

--- a/src/test/java/com/theheroloop/events/MessageTest.java
+++ b/src/test/java/com/theheroloop/events/MessageTest.java
@@ -59,4 +59,28 @@ public class MessageTest
     assertTrue( valid );
   }
 
+  @Test
+  public void testIsNotValidRequestCanceledMessageWithNoLooperId()
+  {
+    var message = MessageBuilder.for_( REQUEST_CANCELED )
+    . setRequestId( "23" )
+    . build();
+
+    var valid = message.isValid();
+
+    assertFalse( valid );
+  }
+
+  @Test
+  public void testIsNotValidRequestCanceledMessageWithNoRequestId()
+  {
+    var message = MessageBuilder.for_( REQUEST_CANCELED )
+    . setLooperId( "23" )
+    . build();
+
+    var valid = message.isValid();
+
+    assertFalse( valid );
+  }
+
 }


### PR DESCRIPTION
I added extra test method to the message class, to ensure that request-canceled events are valid even if they have no hero id